### PR TITLE
Reduce Buildpack strictness from "Rails" to "Rails-compatible"

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -55,14 +55,15 @@ function db_migrate {
 
 function create_asset_plugin {
     puts-step "Enabling static assets plugin"
-    PLUGIN_DIR=$BUILD_DIR/plugins/serve_static_assets
-    mkdir -p $PLUGIN_DIR
-    echo "Rails.application.config.serve_static_assets = true" > $PLUGIN_DIR/init.rb
+    INITIALIZER_DIR="$BUILD_DIR/config/initializers"
+    mkdir -p "$INITIALIZER_DIR"
+    echo "Rails.application.config.serve_static_assets = true" > "$INITIALIZER_DIR/stackato_serve_static_assets.rb"
 }
 
 function compile_rails_assets {
-  set +e bundle exec rake assets:precompile --dry-run 2> /dev/null
-  if [ $? -eq 0 ]; then
+  # Not sure how else to detect a rake task is actually present.
+  if [ $(bundle exec rake -T | grep -c "^rake assets:precompile") -gt 0 ]; then
+    create_asset_plugin
     puts-step "Compiling assets"
     bundle exec rake assets:precompile 2>&1
   fi

--- a/bin/detect
+++ b/bin/detect
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # bin/use <build-dir>
 
-if [ -f $1/config/environment.rb ]; then
-  echo "Ruby/Rails" && exit 0
+if [ -f "$1/config/database.yml" ] && [ -f "$1/config/boot.rb" ]; then
+  echo "Ruby/Rails-Compatible" && exit 0
 else
   echo "no" && exit 1
 fi

--- a/bin/release
+++ b/bin/release
@@ -12,7 +12,7 @@ config_vars:
 EOF
 
 
-[ "$NAME" = "Ruby/Rails" ] || exit 0
+[ "$NAME" = "Ruby/Rails-Compatible" ] || exit 0
 
 cat <<EOF
 

--- a/bin/release
+++ b/bin/release
@@ -17,5 +17,5 @@ EOF
 cat <<EOF
 
 default_process_types:
-  web:      bundle exec rails server
+  web:      bundle exec rackup
 EOF


### PR DESCRIPTION
This does a couple of things:
- Makes the assumption that if the Rails-like files are there, then the app is Rails-y enough. This allows us to run Goliath or Sinatra apps so long as they follow the same conventions. (Previous assumption was `config/environment.rb`, but nothing else in the script actually uses it. This now checks for `config/database.yml` and `config/boot.rb` instead.)
- Runs Asset Precompilation only if the task is actually present. [Rails-API](https://github.com/rails-api/rails-api) apps aren't going to have the task at all, for example.

This is currently running on a test instance; I've pinged you the app name so you can check out the logs if you need to.
